### PR TITLE
Add raw output mode option

### DIFF
--- a/interceptty.1
+++ b/interceptty.1
@@ -135,8 +135,8 @@ interceptty \- Intercept traffic to and from a serial port.
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 32
-\& Usage: ./interceptty [-V] [-qvl] [-s back-set] [-o output-file] 
-\&                      [-p pty-dev] [-t tty-dev] 
+\& Usage: ./interceptty [-V] [-qvlr] [-s back-set] [-o output-file]
+\&                      [-p pty-dev] [-t tty-dev]
 \&                      [-m [pty-owner,[pty-group,]]pty-mode]
 \&                      [-u uid] [-g gid] [-/ chroot-dir]
 \&                      back-device front-device
@@ -154,6 +154,7 @@ interceptty \- Intercept traffic to and from a serial port.
 \&                        '-' to prevent creating a front-device.
 \&                        Doesn't currently do anything.
 \&        -l              Line-buffer output
+\&        -r              Raw output mode (unformatted backend stream)
 \&        -o output-file  Write intercepted data to output-file
 \&        -s back-stty    Use given settings to set up back-device
 \&                        These settings are passed directly to stty(1).
@@ -253,6 +254,12 @@ another program, such as \fItcpserver\fR, \fIinetd\fR, or \fIstunnel\fR.
 .IX Item "-l"
 Line-buffer output, displaying the intercepted data immediately as it
 comes in.
+.IP "\-r" 4
+.IX Item "-r"
+Raw output mode. Intercepted bytes from the backend stream are written
+exactly as received, without direction markers, hex formatting, or
+character annotations. This avoids duplicate characters on echoing
+serial devices.
 .IP "\-o \fIoutput-file\fR" 4
 .IX Item "-o output-file"
 Write output to \fIoutput-file\fR instead of standard output.

--- a/interceptty.c
+++ b/interceptty.c
@@ -63,6 +63,7 @@ char    *backend = NULL,
   *opt_ttyname = NULL;
 int     verbose = 0,
   linebuff = 0,
+  raw_mode = 0,
   quiet = 0,
   timestamp = 0,
   use_eol_ch = 0,
@@ -265,6 +266,15 @@ void dumpbuff(int dir, char *buf, int buflen)
   enum { TSTAMP_SZ = 24 };
   char tstamp[TSTAMP_SZ] = { 0 };
   struct timeval timeVal;
+
+  if (raw_mode)
+  {
+    if (!dir)
+      return;
+    fwrite(buf, 1, buflen, outfile);
+    fflush(outfile);
+    return;
+  }
 
   if (timestamp)
     gettimeofday(&timeVal, NULL);
@@ -744,7 +754,7 @@ int setup_frontend(int f[2])
 
 void usage(char *name)
 {
-  fprintf(stderr,"Usage: %s [-V] [-qvl] [-s back-set] [-o output-file]\n"
+  fprintf(stderr,"Usage: %s [-V] [-qvlr] [-s back-set] [-o output-file]\n"
                 "       %*s [-p pty-dev] [-t tty-dev]\n"
                 "       %*s [-m [pty-owner,[pty-group,]]pty-mode]\n"
                 "       %*s [-u uid] [-g gid] [-/ chroot-dir]\n"
@@ -765,6 +775,7 @@ void usage(char *name)
 "\t\t\t'-' to prevent creating a front-device.\n"
 "\t\t\tDoesn't currently do anything.\n"
 "\t-l\t\tLine-buffer output\n"
+"\t-r\t\tRaw output mode (unformatted backend stream)\n"
 "\t-o output-file\tWrite intercepted data to output-file\n"
 "\t-s back-stty\tUse given settings to set up back-device\n"
 "\t\t\tThese settings are passed directly to stty(1).\n"
@@ -806,11 +817,14 @@ int main (int argc, char *argv[])
   outfile = stdout;
 
   /* Process options */
-  while ((c = getopt(argc, argv, "VTlqvs:o:p:t:m:u:g:/:e:f:")) != EOF)
+  while ((c = getopt(argc, argv, "VTlqrvs:o:p:t:m:u:g:/:e:f:")) != EOF)
     switch (c) {
       case 'q':
 	quiet=1;
 	break;
+      case 'r':
+        raw_mode = 1;
+        break;
       case 'v':
         verbose = 1;
         break;

--- a/interceptty.pod
+++ b/interceptty.pod
@@ -4,8 +4,8 @@ interceptty - Intercept traffic to and from a serial port.
 
 =head1 SYNOPSIS
 
- Usage: ./interceptty [-V] [-qvl] [-s back-set] [-o output-file] 
-                      [-p pty-dev] [-t tty-dev] 
+ Usage: ./interceptty [-V] [-qvlr] [-s back-set] [-o output-file]
+                      [-p pty-dev] [-t tty-dev]
                       [-m [pty-owner,[pty-group,]]pty-mode]
                       [-u uid] [-g gid] [-/ chroot-dir]
                       back-device front-device
@@ -23,6 +23,7 @@ interceptty - Intercept traffic to and from a serial port.
 			'-' to prevent creating a front-device.
 			Doesn't currently do anything.
 	-l		Line-buffer output
+  -r		Raw output mode (unformatted backend stream)
 	-o output-file	Write intercepted data to output-file
 	-s back-stty	Use given settings to set up back-device
 			These settings are passed directly to stty(1).
@@ -128,6 +129,13 @@ another program, such as I<tcpserver>, I<inetd>, or I<stunnel>.
 
 Line-buffer output, displaying the intercepted data immediately as it
 comes in.
+
+=item -r
+
+Raw output mode. Intercepted bytes from the backend stream are written
+exactly as received, without direction markers, hex formatting, or
+character annotations. This avoids duplicate characters on echoing
+serial devices(e.g. Linux terminal).
 
 =item -o I<output-file>
 


### PR DESCRIPTION
 which is useful when monitoring a Linux device's terminal.

- Updated usage instructions to include the -r flag for raw output mode.
- Implemented raw output mode to write intercepted bytes without formatting.